### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -34,10 +34,10 @@ jobs:
       - name: find issues past ${{ env.days-to-alert }} days # ${{ steps.days.outputs.days }} also works
         run: echo "${{ steps.days.outputs.days }}"
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: 1170300
+          client-id: 1170300
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: query graphql for project
         env:


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))

### ⚠️ Action Required
Verify the `APP_ID` variable contains a valid Client ID (`Iv...`) before merging.