### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         with:
           client-id: 1170300
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: query graphql for project
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret